### PR TITLE
Use github HTTPS url for spdlog

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spdlog"]
 	path = spdlog
-	url = git@github.com:gabime/spdlog.git
+	url = https://github.com/gabime/spdlog.git

--- a/src/pyspdlog.cpp
+++ b/src/pyspdlog.cpp
@@ -566,7 +566,7 @@ PYBIND11_MODULE(spdlog, m) {
 
     m.def("set_async_mode", set_async_mode, 
             py::arg("queue_size") = 1 << 16,
-            py::arg("async_overflow_policy") = AsyncOverflowPolicy::block_retry,
+            py::arg("async_overflow_policy") = 0,
             py::arg("worker_warmup_cb") = nullptr,
             py::arg("flush_interval_ms") = 10,
             py::arg("worker_teardown_cb") = nullptr


### PR DESCRIPTION
Switched to use the HTTPS URL, since this is [recommended practice](https://help.github.com/en/articles/which-remote-url-should-i-use#cloning-with-https-urls-recommended), and since it helps address an issue we were having installing this in a Docker container.