### PR TITLE
Pybind11 must be available for setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 
 install:
   - git submodule update --init --recursive
+  - pip install pybind11>=2.2
   - pip install .
 
 script: pytest


### PR DESCRIPTION
Unfortunately, `setup_requires` does not work in conjunction with `ext_modules`, at least to my knowledge. Instead, we have to install pybind11 explicitly prior to building spdlog.