### PR TITLE
Addition of MANIFEST.in to fix packaging for pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md LICENSE setup.py setup.cfg
+graft src
+graft spdlog/include/spdlog


### PR DESCRIPTION
Listing all the files needed in the MANIFEST.in to fix source distribution packaging.

Closes #20.