### PR TITLE
Added requirements to enable wheel building during installation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 
 install:
   - git submodule update --init --recursive
-  - pip install pybind11>=2.2
   - pip install .
 
 script: pytest

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     description='python wrapper around C++ spdlog logging library (https://github.com/bodgergely/spdlog-python)',
     license='MIT',
     long_description='python wrapper (https://github.com/bodgergely/spdlog-python) around C++ spdlog (http://github.com/gabime/spdlog.git) logging library.',
-    setup_requires=['pytest-runner'],
+    setup_requires=['wheel', 'pybind11>=2.2', 'pytest-runner'],
     install_requires=['pybind11>=2.2'],
     tests_require=['pytest'],
     ext_modules=[


### PR DESCRIPTION
When installing spdlog-python building a wheel failed due to missing requirements, if pybind11 was not already installed. Adding it to the requirements in setup.py should fix that.