### PR TITLE
Updated to spdlog version to 1.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,19 @@ class get_pybind_include(object):
         import pybind11
         return pybind11.get_include(self.user)
 
+def get_include_dirs():
+    include_dirs=[
+        'spdlog/include/',
+        get_pybind_include(),
+        get_pybind_include(user=True),
+    ]
+
+    conda_prefix = os.environ.get('CONDA_PREFIX')
+    if conda_prefix is not None:
+        include_dirs.append("{}/include".format(conda_prefix))
+    
+    return include_dirs
+
 
 def include_dir_files(folder):
     """Find all C++ header files in folder"""
@@ -61,11 +74,7 @@ setup(
         Extension(
             'spdlog',
             ['src/pyspdlog.cpp'],
-            include_dirs=[
-                'spdlog/include/',
-                get_pybind_include(),
-                get_pybind_include(user=True)
-            ],
+            include_dirs=get_include_dirs(),
             libraries=link_libs(),
             extra_compile_args=["-std=c++11", "-v"],
             language='c++11'

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def get_include_dirs():
 
     conda_prefix = os.environ.get('CONDA_PREFIX')
     if conda_prefix is not None:
-        include_dirs.append("{}/include".format(conda_prefix))
+        include_dirs.append(os.path.join(conda_prefix, "include"))
     
     return include_dirs
 

--- a/src/pyspdlog.cpp
+++ b/src/pyspdlog.cpp
@@ -253,17 +253,17 @@ public:
 #ifdef SPDLOG_ENABLE_SYSLOG
 class syslog_sink_st : public Sink {
 public:
-    syslog_sink_st(const std::string& ident = "", int syslog_option = 0, int syslog_facility = (1 << 3))
+    syslog_sink_st(const std::string& ident = "", int syslog_option = 0, int syslog_facility = (1 << 3), bool enable_formatting = true)
     {
-        _sink = std::make_shared<spdlog::sinks::syslog_sink_st>(ident, syslog_option, syslog_facility);
+        _sink = std::make_shared<spdlog::sinks::syslog_sink_st>(ident, syslog_option, syslog_facility, enable_formatting);
     }
 };
 
 class syslog_sink_mt : public Sink {
 public:
-    syslog_sink_mt(const std::string& ident = "", int syslog_option = 0, int syslog_facility = (1 << 3))
+    syslog_sink_mt(const std::string& ident = "", int syslog_option = 0, int syslog_facility = (1 << 3), bool enable_formatting = true)
     {
-        _sink = std::make_shared<spdlog::sinks::syslog_sink_mt>(ident, syslog_option, syslog_facility);
+        _sink = std::make_shared<spdlog::sinks::syslog_sink_mt>(ident, syslog_option, syslog_facility, enable_formatting);
     }
 };
 #endif
@@ -347,14 +347,9 @@ public:
         return snks;
     }
 
-    void set_error_handler(spd::log_err_handler handler)
+    void set_error_handler(spd::err_handler handler)
     {
         _logger->set_error_handler(handler);
-    }
-
-    spd::log_err_handler error_handler()
-    {
-        return _logger->error_handler();
     }
 
     std::shared_ptr<spdlog::logger> get_underlying_logger() {
@@ -785,7 +780,6 @@ PYBIND11_MODULE(spdlog, m)
         .def("async_mode", &Logger::async)
         .def("sinks", &Logger::sinks)
         .def("set_error_handler", &Logger::set_error_handler)
-        .def("error_handler", &Logger::error_handler)
         .def("get_underlying_logger", &Logger::get_underlying_logger);
 
     py::class_<SinkLogger, Logger>(m, "SinkLogger")

--- a/src/pyspdlog.cpp
+++ b/src/pyspdlog.cpp
@@ -848,15 +848,17 @@ py::class_<DailyLogger, Logger>(m, "DailyLogger")
 //SyslogLogger(const std::string& logger_name, const std::string& ident = "", int syslog_option = 0, int syslog_facilty = (1<<3))
 #ifdef SPDLOG_ENABLE_SYSLOG
 py::class_<syslog_sink_st, Sink>(m, "syslog_sink_st")
-    .def(py::init<std::string, int, int>(),
+    .def(py::init<std::string, int, int, bool>(),
         py::arg("ident") = "",
         py::arg("syslog_option") = 0,
-        py::arg("syslog_facility") = (1 << 3));
+        py::arg("syslog_facility") = (1 << 3),
+        py::arg("enable_formatting") = true);
 py::class_<syslog_sink_mt, Sink>(m, "syslog_sink_mt")
-    .def(py::init<std::string, int, int>(),
+    .def(py::init<std::string, int, int, bool>(),
         py::arg("ident") = "",
         py::arg("syslog_option") = 0,
-            py::arg("syslog_facility") = (1 << 3));
+        py::arg("syslog_facility") = (1 << 3),
+        py::arg("enable_formatting") = true);
     py::class_<SyslogLogger, Logger>(m, "SyslogLogger")
         .def(py::init<std::string, bool, std::string, int, int>(),
             py::arg("name"),


### PR DESCRIPTION
When in a Conda environment appends the environment's include path. This allows for inclusion in Conda environments which already contain Spdlog.

The error_handler method appears to have been removed in newer versions of Spdlog. I wasn't sure how to handle this so I opted for the easy route of simply removing the `error_handler` method from spdlog-python. An alternate approach would be to sublass Sdplog's `logger` class and implement the `error_handler` method.